### PR TITLE
Reactiva IA de menú semanal con opción de despensa y endpoint Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,50 @@ Al iniciar sesión correctamente se guarda una sesión local en `sessionStorage`
 ## Datos persistidos
 
 - Calendario: `family_v9/calendar`
-- Lista de compra: `family_v9/pantry`
+- Lista de compra / despensa: `family_v9/pantry`
 
-## IA
+## IA (reactivada)
 
-La generación de recetas por API externa quedó desactivada para eliminar la dependencia de Vercel.
+La generación de menú vuelve a estar activa para:
+
+- Menú de **7 días** con **comidas y cenas**.
+- Generación usando ingredientes desde:
+  - la **Despensa** (lista de compra), o
+  - ingredientes manuales escritos en el planner.
+
+El frontend llama a un endpoint externo (`POST /api/ai-recipes`) y espera la forma:
+
+```json
+{
+  "comidas": [{ "dia": "Lunes", "plato": "..." }],
+  "cenas": [{ "dia": "Lunes", "plato": "..." }]
+}
+```
+
+## ¿Hace falta Vercel?
+
+**Sí, solo para IA** si quieres mantener el frontend estático en GitHub Pages/Firebase Hosting sin exponer la `OPENAI_API_KEY`.
+
+Recomendación:
+
+1. Mantener frontend estático (sin backend propio para auth).
+2. Desplegar **solo** la función `api/ai-recipes.js` en Vercel.
+3. Sin autenticación para esa ruta (como pediste), pero con:
+   - CORS restringido a tu dominio,
+   - rate limiting (ideal en Vercel o proxy),
+   - validación estricta del payload.
+
+Configurable en frontend con:
+
+```html
+<script>
+  window.SALCHIPAPAS_AI_API_URL = 'https://TU-PROYECTO.vercel.app/api/ai-recipes';
+</script>
+```
+
+Si no defines esta variable, usa por defecto:
+
+- `https://salchipapas-ai.vercel.app/api/ai-recipes`
 
 ## Troubleshooting
 
@@ -39,5 +78,6 @@ Pasos recomendados:
 ## Estructura
 
 - `js/services/firebase.js`: lectura/escritura de Firebase.
-- `js/services/api.js`: capa de acceso usada por la app (login + calendario + compra).
+- `js/services/api.js`: login Firebase + calendario + compra + IA.
+- `js/services/ai.js`: orquestación de prompts de menú y aceptación en calendario.
 - `js/security/auth.js`: control de pantalla de login y cierre de sesión.

--- a/api/ai-recipes.js
+++ b/api/ai-recipes.js
@@ -1,10 +1,10 @@
 const OpenAI = require('openai');
-const { requireAuth, sendError } = require('../lib/auth');
-const withCors = require('../lib/withCors');
+const { sendError } = require('../salchipapas-api/lib/auth');
+const withCors = require('../salchipapas-api/lib/withCors');
 
 const SYSTEM_PROMPT = 'Devuelve SOLO JSON válido con esta forma: {"comidas":[{"dia":"Lunes","plato":"..."}],"cenas":[{"dia":"Lunes","plato":"..."}]}. Deben ser exactamente 7 comidas y 7 cenas.';
 
-module.exports = withCors(requireAuth(async (req, res) => {
+module.exports = withCors(async (req, res) => {
   if (req.method !== 'POST') return sendError(res, 405, 'METHOD_NOT_ALLOWED', 'Solo POST');
 
   const apiKey = process.env.OPENAI_API_KEY;
@@ -31,4 +31,4 @@ module.exports = withCors(requireAuth(async (req, res) => {
   }
 
   return res.status(200).json({ ok: true, data: parsed });
-}));
+});

--- a/js/ui/index.js
+++ b/js/ui/index.js
@@ -34,7 +34,20 @@ export function createUi(app) {
             document.getElementById(id).classList.add('active');
             document.querySelector(`[data-tab="${id}"]`).classList.add('active', 'text-primary');
             if (id === 'planner') {
-                document.getElementById('planner').innerHTML = `<h2 class="text-2xl font-bold mb-6">IA Planner</h2><button data-action="ai-generate-menu" class="bg-primary text-white w-full py-4 rounded-3xl font-bold shadow-lg">✨ Generar Menú Semanal</button><div id="plannerResults" class="mt-8 pb-20"></div>`;
+                document.getElementById('planner').innerHTML = `
+                    <h2 class="text-2xl font-bold mb-6">IA Planner</h2>
+                    <div class="bg-white rounded-3xl border p-4 space-y-3">
+                        <label class="block text-[10px] font-bold text-gray-500 uppercase">Fuente de ingredientes</label>
+                        <select id="plannerSource" class="w-full rounded-2xl bg-gray-50 border-none text-sm">
+                            <option value="pantry">Usar Despensa (Compra)</option>
+                            <option value="custom">Escribir ingredientes</option>
+                        </select>
+                        <textarea id="plannerIngredients" class="w-full rounded-2xl bg-gray-50 border-none text-xs h-24" placeholder="Ej: arroz, pollo, tomate"></textarea>
+                        <p class="text-[10px] text-gray-500">Si eliges Despensa se usarán automáticamente los ingredientes de la lista de compra.</p>
+                        <button data-action="ai-generate-menu" class="bg-primary text-white w-full py-4 rounded-3xl font-bold shadow-lg">✨ Generar Menú Semanal</button>
+                    </div>
+                    <div id="plannerResults" class="mt-8 pb-20"></div>
+                `;
             }
             app.render();
         },


### PR DESCRIPTION
### Motivation
- Reactivar la generación de menús por IA para ofrecer un planner de 7 días con comidas y cenas usando ingredientes reales desde la despensa o escritos manualmente.
- Permitir mantener el frontend estático sin exponer la `OPENAI_API_KEY` moviendo la lógica de IA a un endpoint serverless (p. ej. Vercel) que el cliente pueda consumir.

### Description
- Implementa `generateAiRecipes(ingredients)` en `js/services/api.js` que hace `POST` al endpoint IA configurable vía `window.SALCHIPAPAS_AI_API_URL` con fallback `https://salchipapas-ai.vercel.app/api/ai-recipes` y valida la respuesta JSON.
- Actualiza `js/services/ai.js` para aceptar una fuente de ingredientes (Despensa o manual), parsear/validar los ingredientes y orquestar la generación del plan semanal de comidas y cenas.
- Añade controles UI en `js/ui/index.js` (selector `plannerSource` y `plannerIngredients`) para elegir la fuente y escribir ingredientes manuales antes de generar el menú.
- Crea/ajusta `api/ai-recipes.js` como función serverless que llama a OpenAI, valida payload y formato (7 comidas y 7 cenas) y expone la ruta sin autenticación del frontend (se conserva validación y CORS a nivel de función).
- Documenta la reactivación y la recomendación de desplegar solo la función IA en Vercel en `README.md` y deja la URL cliente configurable.

### Testing
- Ejecuté comprobaciones sintácticas con `node --check js/services/api.js`, `node --check js/services/ai.js`, `node --check js/ui/index.js` y `node --check api/ai-recipes.js`, todas completadas sin errores.
- Intenté levantar un servidor estático y capturar una captura con Playwright; la navegación falló en este entorno con `ERR_EMPTY_RESPONSE`, por lo que no se generó la captura de pantalla.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994602f1f5c8324a663f3abada073ed)